### PR TITLE
Upgrade site configuration for Antora v3

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: stream-contrib
 title: Contributor's Guide
-version: master
-start_page: ROOT:index
+version: ~
+start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc

--- a/site.yml
+++ b/site.yml
@@ -16,5 +16,5 @@ output:
   destinations:
   - provider: archive
 runtime:
-  pull: true
+  fetch: true
   cache_dir: ./cache


### PR DESCRIPTION
Basic changes to allow the site to be built without warnings or errors using Antora v3.

Changed the `antora.yml::version` to use the [Antora unversioned token](https://docs.antora.org/antora/latest/component-version-key). This can be reverted if the infra actually does need a refname.