### PR TITLE
Update source-git.adoc

### DIFF
--- a/modules/ROOT/pages/contributing/source-git.adoc
+++ b/modules/ROOT/pages/contributing/source-git.adoc
@@ -30,9 +30,8 @@ Now you need to annotate the git commit which matches the patch with the respect
 ----
 We need this change in CentOS Stream
 
-patch_name: my-special-change.patch
-
 Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>
+patch_name: my-special-change.patch
 
 ---
  src/code.c | 17 +++++++++--------


### PR DESCRIPTION
Changing position of patch name annotation in commit as git returns only last trailers block and using previous format will have no effect on patch name used by packit as it won't see the name.