### PR TITLE
Update quickstart guide to reference RHEL project

### DIFF
--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -93,7 +93,7 @@ For example, if you see a package that is listed in the `-gate` tag but not the 
 
 === Pungi and the Compose Configs
 
-If you want to make changes to the overall distribution itself, or the artifacts produced by composes, or you’ll want to refer to the `Distribution` component in the RHEL project. Please file an appropriate issue describing the change you’d like to make.
+If you want to make changes to the overall distribution itself, or the artifacts produced by composes, you’ll want to refer to the `Distribution` component in the RHEL project. Please file an appropriate issue describing the change you’d like to make.
 
 If you’re familiar with Pungi, you’ll recognize the configs in https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos
 

--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -13,7 +13,8 @@ To start making contributions you’ll need to log in to the following places:
 
 * CentOS Account System - https://accounts.centos.org/[Sign Up]
 
-* Bugzilla - https://bugzilla.redhat.com/saml2_login.cgi?idp=Fedora%20Account%20System&target=enter_bug.cgi[Sign In] using the link for the Fedora Account System using your CentOS Account (CentOS and Fedora now share an authentication system, so your password works in both places)
+* Red Hat Issues - https://issues.redhat.com/[Sign Up]
+
 
 === Tools and workstation setup
 
@@ -24,15 +25,15 @@ To work with dist-git repositories and inspect artifacts or logs in the buildsys
 
 == What you do, what the RHEL maintainer takes care of
 
-=== 1.) File a bugzilla!
+=== 1.) File an issue!
 
-CentOS Stream bugs are filed under the Red Hat Enterprise Linux products in bugzilla, https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Enterprise%20Linux%209&version=CentOS%20Stream[File a bug against CentOS Stream / RHEL 9]
+CentOS Stream defects and feature requests are filed under the RHEL project in issues.redhat.com, https://issues.redhat.com/projects/RHEL[Create an issue against CentOS Stream / RHEL 9]
 
 The `Component` is the name of the package that you want to patch
 
-Describe the change that you’d like to make, be sure to double-check for existing bugs that describe the feature request or issue that you’re seeing
+Describe the change that you’d like to make, be sure to double-check for existing issues that describe the feature request or problem that you’re seeing
 
-RHEL developers use bugzillas to coordinate with RHEL QE, schedule work with other maintainers, and track progress against development milestones. RHEL maintainers need to get a bugzilla `approved` for a release before they can merge your change, but don’t worry, this is something they take care of for you. You just need to file the bug and reference it.
+RHEL developers use issues to coordinate with RHEL QE, schedule work with other maintainers, and track progress against development milestones. RHEL maintainers need to get an issue `approved` for a release before they can merge your change, but don’t worry, this is something they take care of for you. You just need to file the issue and reference it.
 
 === 2.) Develop your patch
 
@@ -42,14 +43,13 @@ There are 2 ways to contribute, *Source Git* is in use by developers of packages
 
 In the Gitlab repository you want to change, click the `Fork` button on the front page to create your own fork.
 
-=== 3.) Reference the bugzilla you filed in your commits
+=== 3.) Reference the issue you filed in your commits
 
 Examples:
 
-* `git commit --signoff -m 'This is my awesome patch, Related: rhbz#123456`
-* `git commit --signoff -m 'This is another patch to the same bug, Resolves: #123456 (The checkers let me leave off the rhbz prefix)'`
+* `git commit --signoff -m 'RHEL-1234 This is my awesome patch`
 
-Every commit made during your contribution MUST come with a Bugzilla referenced in the commit message.
+Every commit made during your contribution MUST come with an issue referenced in the commit message.
 
 Once the commits are how you like them, push to your fork in Gitlab.
 
@@ -93,7 +93,7 @@ For example, if you see a package that is listed in the `-gate` tag but not the 
 
 === Pungi and the Compose Configs
 
-If you want to make changes to the overall distribution itself, or the artifacts produced by composes, or you’ll want to refer to the `Distribution` component in Bugzilla. Please file an appropriate bugzilla describing the change you’d like to make.
+If you want to make changes to the overall distribution itself, or the artifacts produced by composes, or you’ll want to refer to the `Distribution` component in the RHEL project. Please file an appropriate issue describing the change you’d like to make.
 
 If you’re familiar with Pungi, you’ll recognize the configs in https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos
 
@@ -101,6 +101,6 @@ These configs follow a Fork/Merge-Request workflow and require review from CentO
 
 === The Comps
 
-Comps control package groups, and repository split configurations. Changes here most likely require a `Distribution` component bug in bugzilla.
+Comps control package groups, and repository split configurations. Changes here most likely require a `Distribution` component issue in the RHEL project.
 
 https://gitlab.com/redhat/centos-stream/release-engineering/comps


### PR DESCRIPTION
RHEL is moving away from bugzilla and using
https://issues.redhat.com/projects/RHEL as its main issue tracker.  Update the quickstart to use this instead of bugzilla.